### PR TITLE
Modifying csv output format for compatibility

### DIFF
--- a/Python_interface/comet/core/io_utils.py
+++ b/Python_interface/comet/core/io_utils.py
@@ -265,7 +265,7 @@ def save_dataset_as_thunderstorm_csv(dataset, savename=None):
         savename = asksaveasfilename(title="Save as ThunderSTORM CSV", defaultextension=".csv")
 
     df = pd.DataFrame({
-        "frame": dataset[:, 3].astype(int) + 1, # 1-based frame 
+        "frame": dataset[:, 3].astype(int),
         "x [nm]": dataset[:, 0],
         "y [nm]": dataset[:, 1],
     })


### PR DESCRIPTION
The current output format of the script does not include the locs ID which prevented loading into NEO Analysis. Also, the frame key should start at 1 for compatibility. 

This PR also includes a small additional formatting change by setting the float precision to 3 digits, reducing the output file size. (noone needs a precision of 1/1000 of an Angstrom!) 